### PR TITLE
Fix res_query() calls; fix MX record handling during auto-d.

### DIFF
--- a/SourceCode/DnDns/DnDns/Query/DnsQueryResponse.cs
+++ b/SourceCode/DnDns/DnDns/Query/DnsQueryResponse.cs
@@ -96,8 +96,15 @@ namespace DnDns.Query
 		}
 
 		public void ParseResponse(byte[] recvBytes)
-		{
-			MemoryStream memoryStream = new MemoryStream(recvBytes);
+        {
+            if (null != recvBytes) {
+                ParseResponse (recvBytes, recvBytes.Length);
+            }
+        }
+
+        public void ParseResponse(byte[] recvBytes, int length)
+        {
+			MemoryStream memoryStream = new MemoryStream(recvBytes, 0, length);
             byte[] flagBytes = new byte[2];
             byte[] transactionId = new byte[2];
 			byte[] questions = new byte[2];
@@ -107,7 +114,7 @@ namespace DnDns.Query
             byte[] nsType = new byte[2];
             byte[] nsClass = new byte[2];
 
-			this._bytesReceived = recvBytes.Length;
+			this._bytesReceived = length;
 
 			// Parse DNS Response
 			memoryStream.Read(transactionId, 0, 2);

--- a/SourceCode/DnDns/DnDns/Records/BaseDnsRecord.cs
+++ b/SourceCode/DnDns/DnDns/Records/BaseDnsRecord.cs
@@ -298,8 +298,11 @@ namespace DnDns.Records
                         Debug.Assert(next < 0xc0, "Offset cannot be greater then 0xc0.");
                         byte[] buffer = new byte[next];
                         ms.Read(buffer, 0, (int)next);
-                        sb.Append(Encoding.ASCII.GetString(buffer) + ".");
+                        sb.Append(Encoding.ASCII.GetString(buffer));
                         next = (uint)ms.ReadByte();
+                        if (next != 0x00) {
+                            sb.Append (".");
+                        }
                         Trace.WriteLine("0x" + next.ToString("x2"));
                         break;
                     }

--- a/SourceCode/DnDns/DnDns/Tools.cs
+++ b/SourceCode/DnDns/DnDns/Tools.cs
@@ -202,7 +202,7 @@ namespace DnDns
         }
 
 #if __IOS__
-        [DllImport("__Internal")]
+        [DllImport("__Internal", EntryPoint = "res_9_query")]
         private static extern int res_query (string host, int queryClass, int queryType, byte[] answer, int anslen);
         public const bool HasSystemDns = true;
 #else


### PR DESCRIPTION
(This change goes along with a corresponding change to NachoClientX.)

Fix the calls to the C library function res_query(), which handles DNS
resolution.  The old code was calling the wrong function.  The correct
function is in libresolv.dylib, so the project files had to be changed
to link in that library.

Fix the way that DNS responses are parsed, so an extra period isn't
added to the end of domain names.

Fix an bug in the handling of MX queries in the auto-discovery state
machine.  The old code would fail with an assertion if the MX query
was actually successful.

This change should improve auto-d for Google accounts.  With luck, you
shouldn't have to type in m.google.com.  But the MX query fails
intermittently, causing auto-d to fail.  (Automatic retries will be a
later update.)  And I haven't done an end-to-end test yet, so I won't
gaurantee that it works yet.
